### PR TITLE
Add ErrorAction to Get-Process

### DIFF
--- a/functions/Backup-VSCode.ps1
+++ b/functions/Backup-VSCode.ps1
@@ -47,7 +47,7 @@ function Backup-VSCode {
     
     process {
         #Can't read some files while Code is running
-        $CodeRunning = Get-Process code
+        $CodeRunning = Get-Process -Name code -ErrorAction SilentlyContinue
         
         if($CodeRunning) {
             Write-Verbose "Closing VS Code"


### PR DESCRIPTION
Added ErrorAction SilentlyContinue to Get-Process command. If VSCode isn't running, such that a backup is created from the ConsoleHost/part of a profile script, an error is thrown.